### PR TITLE
feat: 프로젝트 섹션 슬라이드 UI 개선

### DIFF
--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -9,12 +9,6 @@
     transform: translateY(0);
 }
 
-.projects-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    gap: 2rem;
-}
-
 .projects-section-header {
     display: flex;
     align-items: center;
@@ -29,13 +23,113 @@
     font-weight: 700;
 }
 
-.projects-section-header span {
-    color: rgba(255, 255, 255, 0.65);
+.projects-section-header span,
+.project-detail-label,
+.project-tile-action {
+    color: var(--text-muted);
     font-size: 0.9rem;
 }
 
+.projects-slider-shell {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.projects-slider-button {
+    width: 40px;
+    height: 40px;
+    border-radius: 999px;
+    border: 1px solid var(--border-glass);
+    background: var(--bg-glass);
+    color: var(--text-main);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: var(--transition);
+    flex-shrink: 0;
+    z-index: 1;
+}
+
+.projects-slider-button:hover {
+    background: var(--bg-glass-hover);
+    border-color: var(--border-glass-strong);
+}
+
+.projects-slider-button-left,
+.projects-slider-button-right {
+    align-self: stretch;
+    height: auto;
+    min-height: 100%;
+    border-radius: 18px;
+    padding: 0;
+}
+
+.projects-slider {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: calc((100% - 3rem) / 4);
+    gap: 1rem;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+    scroll-snap-type: x proximity;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(99, 102, 241, 0.45) transparent;
+    cursor: grab;
+    user-select: none;
+}
+
+.projects-slider.is-dragging {
+    cursor: grabbing;
+    scroll-snap-type: none;
+}
+
+.projects-slider::-webkit-scrollbar {
+    height: 8px;
+}
+
+.projects-slider::-webkit-scrollbar-thumb {
+    background: rgba(99, 102, 241, 0.45);
+    border-radius: 999px;
+}
+
+.project-tile {
+    padding: 0;
+    overflow: hidden;
+    min-height: 0;
+    scroll-snap-align: start;
+}
+
+.project-tile.is-selected {
+    border-color: var(--border-glass-strong);
+    box-shadow: 0 16px 40px -24px rgba(99, 102, 241, 0.85);
+}
+
+.project-tile-button {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    padding: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    text-align: left;
+    user-select: none;
+}
+
+.project-tile-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
 .project-icon-wrap {
-    margin-bottom: 1.25rem;
     width: 48px;
     height: 48px;
     border-radius: 12px;
@@ -43,42 +137,89 @@
     display: flex;
     align-items: center;
     justify-content: center;
-}
-
-.project-desc {
-    margin: 1rem 0;
-    font-size: 0.95rem;
-    line-height: 1.6;
+    flex-shrink: 0;
 }
 
 .project-status {
     display: inline-flex;
     align-items: center;
-    margin-top: 0.5rem;
-    margin-bottom: 0.25rem;
     padding: 0.35rem 0.75rem;
     border-radius: 999px;
     background: rgba(34, 197, 94, 0.12);
     border: 1px solid rgba(34, 197, 94, 0.28);
     color: #86efac;
-    font-size: 0.82rem;
+    font-size: 0.76rem;
     font-weight: 600;
+    text-align: center;
+}
+
+.project-status-in-progress {
+    background: rgba(249, 115, 22, 0.14);
+    border-color: rgba(249, 115, 22, 0.32);
+    color: #fdba74;
+}
+
+.project-tile-body {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.project-tile-body h3 {
+    margin: 0;
+    font-size: 1.05rem;
+    line-height: 1.35;
+}
+
+.project-desc {
+    margin: 0;
+    font-size: 0.92rem;
+    line-height: 1.6;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.project-tile-footer {
+    padding-top: 0.75rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.project-detail-card {
+    margin-top: 1.5rem;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.project-detail-toolbar {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.project-detail-toolbar h3 {
+    margin-top: 0.35rem;
+}
+
+.project-detail-description {
+    margin: 0;
+    line-height: 1.7;
 }
 
 .project-highlights {
-    margin: 0 0 1.5rem 1.25rem;
-    padding: 0;
+    margin: 0;
+    padding-left: 1.25rem;
     list-style-type: disc;
-    font-size: 0.85rem;
-    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.95rem;
+    color: var(--text-muted);
 }
 
 .project-highlights li {
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.5rem;
 }
 
 .project-tags {
-    margin-bottom: 1.5rem;
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
@@ -102,7 +243,7 @@
 .btn-outline {
     background: transparent;
     border: 1px solid rgba(255, 255, 255, 0.2);
-    color: #fff;
+    color: var(--text-main);
     transition: all 0.3s ease;
 }
 
@@ -119,4 +260,44 @@
     gap: 0.5rem;
     border-radius: 8px;
     text-decoration: none;
+}
+
+@media (max-width: 1024px) {
+    .projects-slider {
+        grid-auto-columns: minmax(220px, 31vw);
+    }
+}
+
+@media (max-width: 768px) {
+    .projects-section-header,
+    .project-detail-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .projects-slider-shell {
+        gap: 0.75rem;
+    }
+
+    .projects-slider {
+        grid-auto-columns: minmax(220px, 78vw);
+    }
+
+    .project-tile-button {
+        padding: 1rem;
+    }
+}
+
+@media (max-width: 520px) {
+    .projects-slider-shell {
+        gap: 0.5rem;
+    }
+
+    .projects-slider {
+        grid-auto-columns: minmax(220px, 88vw);
+    }
+
+    .projects-slider-button {
+        width: 36px;
+    }
 }

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,4 +1,5 @@
-import { ExternalLink } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight, ExternalLink, FolderOpen, X } from 'lucide-react';
 import { projects, iconMap } from '../data/portfolio';
 import { useScrollReveal } from '../hooks/useScrollReveal';
 import SectionHeader from './ui/SectionHeader';
@@ -7,66 +8,251 @@ import './Projects.css';
 
 export default function Projects() {
     const { ref, isVisible } = useScrollReveal();
-    const inProgressProjects = projects.filter((project) => project.status === '프로젝트 진행 중');
-    const completedProjects = projects.filter((project) => project.status !== '프로젝트 진행 중');
+    const sliderRef = useRef(null);
+    const dragStateRef = useRef({
+        isDragging: false,
+        startX: 0,
+        startScrollLeft: 0,
+        moved: false,
+        pointerId: null,
+    });
+    const suppressClickRef = useRef(false);
+    const sortedProjects = [...projects].sort((a, b) => {
+        const aInProgress = a.status === '진행중';
+        const bInProgress = b.status === '진행중';
 
-    const renderProjectList = (projectList, sectionTitle) => (
-        <>
-            <div className="projects-section-header">
-                <h3>{sectionTitle}</h3>
-                <span>{projectList.length}개</span>
-            </div>
+        if (aInProgress === bInProgress) {
+            return 0;
+        }
 
-            <div className="projects-grid">
-                {projectList.map((project, index) => {
-                    const Icon = iconMap[project.iconName];
-                    return (
-                        <GlassCard key={`${sectionTitle}-${project.title}`} delay={index * 100}>
-                            <div className="project-icon-wrap">
-                                {Icon && <Icon size={24} color={project.iconColor} />}
-                            </div>
-                            <h3>{project.title}</h3>
-                            {project.status && <p className="project-status">진행 상태: {project.status}</p>}
-                            <p className="project-desc">{project.description}</p>
-                            {project.highlights && (
-                                <ul className="project-highlights">
-                                    {project.highlights.map((highlight, idx) => (
-                                        <li key={idx}>{highlight}</li>
-                                    ))}
-                                </ul>
-                            )}
-                            <div className="project-tags">
-                                {project.tags.map((tag) => (
-                                    <span key={tag} className="project-tag">
-                                        {tag}
-                                    </span>
-                                ))}
-                            </div>
-                            <div className="project-links">
-                                <a href={project.link} className="btn btn-secondary btn-sm" target="_blank" rel="noopener noreferrer">
-                                    <ExternalLink size={16} />
-                                    GitHub
-                                </a>
-                                {project.projectPage && (
-                                    <a href={project.projectPage} className="btn btn-outline btn-sm" target="_blank" rel="noopener noreferrer">
-                                        프로젝트 페이지
-                                    </a>
-                                )}
-                            </div>
-                        </GlassCard>
-                    );
-                })}
-            </div>
-        </>
-    );
+        return aInProgress ? 1 : -1;
+    });
+    const [selectedProject, setSelectedProject] = useState(sortedProjects[0] ?? null);
+    const [isDraggingSlider, setIsDraggingSlider] = useState(false);
+
+    const scrollProjects = (direction) => {
+        if (!sliderRef.current) {
+            return;
+        }
+
+        const scrollAmount = sliderRef.current.clientWidth * 0.72 * direction;
+
+        sliderRef.current.scrollBy({
+            left: scrollAmount,
+            behavior: 'smooth',
+        });
+    };
+
+    const handleSelectProject = (project, event) => {
+        if (suppressClickRef.current) {
+            suppressClickRef.current = false;
+            event.preventDefault();
+            return;
+        }
+
+        setSelectedProject(project);
+
+        event.currentTarget.closest('.project-tile')?.scrollIntoView({
+            behavior: 'smooth',
+            inline: 'center',
+            block: 'nearest',
+        });
+    };
+
+    const handlePointerDown = (event) => {
+        if (!sliderRef.current || (event.pointerType === 'mouse' && event.button !== 0)) {
+            return;
+        }
+
+        dragStateRef.current = {
+            isDragging: true,
+            startX: event.clientX,
+            startScrollLeft: sliderRef.current.scrollLeft,
+            moved: false,
+            pointerId: event.pointerId,
+        };
+
+        sliderRef.current.setPointerCapture?.(event.pointerId);
+        setIsDraggingSlider(true);
+    };
+
+    const handlePointerMove = (event) => {
+        if (!sliderRef.current || !dragStateRef.current.isDragging) {
+            return;
+        }
+
+        const deltaX = event.clientX - dragStateRef.current.startX;
+
+        if (Math.abs(deltaX) > 6) {
+            dragStateRef.current.moved = true;
+            suppressClickRef.current = true;
+        }
+
+        if (!dragStateRef.current.moved) {
+            return;
+        }
+
+        sliderRef.current.scrollLeft = dragStateRef.current.startScrollLeft - deltaX;
+    };
+
+    const endDragging = () => {
+        dragStateRef.current.isDragging = false;
+        dragStateRef.current.pointerId = null;
+        setIsDraggingSlider(false);
+    };
+
+    const handlePointerUp = (event) => {
+        if (dragStateRef.current.pointerId !== event.pointerId) {
+            return;
+        }
+
+        sliderRef.current?.releasePointerCapture?.(event.pointerId);
+        endDragging();
+    };
+
+    const handlePointerCancel = (event) => {
+        if (dragStateRef.current.pointerId !== event.pointerId) {
+            return;
+        }
+
+        sliderRef.current?.releasePointerCapture?.(event.pointerId);
+        endDragging();
+    };
 
     return (
         <section className="section" id="projects" ref={ref}>
             <div className="container">
                 <div className={`projects-wrapper ${isVisible ? 'reveal' : ''}`}>
                     <SectionHeader subtitle="Portfolio" title="주요 프로젝트" />
-                    {completedProjects.length > 0 && renderProjectList(completedProjects, '완료된 프로젝트')}
-                    {inProgressProjects.length > 0 && renderProjectList(inProgressProjects, '진행 중인 프로젝트')}
+
+                    <div className="projects-section-header">
+                        <h3>프로젝트 목록</h3>
+                        <span>프로젝트가 추가되면 오른쪽으로 이어서 표시됩니다</span>
+                    </div>
+
+                    <div className="projects-slider-shell">
+                        <button
+                            type="button"
+                            className="projects-slider-button projects-slider-button-left"
+                            onClick={() => scrollProjects(-1)}
+                            aria-label="이전 프로젝트 보기"
+                        >
+                            <ChevronLeft size={18} />
+                        </button>
+
+                        <div
+                            className={`projects-slider ${isDraggingSlider ? 'is-dragging' : ''}`}
+                            ref={sliderRef}
+                            role="list"
+                            aria-label="프로젝트 목록"
+                            onPointerDown={handlePointerDown}
+                            onPointerMove={handlePointerMove}
+                            onPointerUp={handlePointerUp}
+                            onPointerCancel={handlePointerCancel}
+                        >
+                            {sortedProjects.slice(0, 16).map((project, index) => {
+                                const Icon = iconMap[project.iconName];
+                                const isSelected = selectedProject?.title === project.title;
+
+                            return (
+                                <GlassCard
+                                    key={project.title}
+                                    className={`project-tile ${isSelected ? 'is-selected' : ''}`}
+                                    delay={index * 80}
+                                    >
+                                        <button
+                                            type="button"
+                                            className="project-tile-button"
+                                            onClick={(event) => handleSelectProject(project, event)}
+                                            aria-pressed={isSelected}
+                                        >
+                                            <div className="project-tile-top">
+                                            <div className="project-icon-wrap">
+                                                    {Icon && <Icon size={24} color={project.iconColor} />}
+                                                </div>
+                                                {project.status && (
+                                                    <span
+                                                        className={`project-status ${project.status === '진행중' ? 'project-status-in-progress' : ''}`}
+                                                    >
+                                                        {project.status}
+                                                    </span>
+                                                )}
+                                            </div>
+
+                                            <div className="project-tile-body">
+                                                <h3>{project.title}</h3>
+                                                <p className="project-desc">{project.description}</p>
+                                            </div>
+
+                                            <div className="project-tile-footer">
+                                                <span className="project-tile-action">클릭해서 자세히 보기</span>
+                                            </div>
+                                        </button>
+                                    </GlassCard>
+                                );
+                            })}
+                        </div>
+
+                        <button
+                            type="button"
+                            className="projects-slider-button projects-slider-button-right"
+                            onClick={() => scrollProjects(1)}
+                            aria-label="다음 프로젝트 보기"
+                        >
+                            <ChevronRight size={18} />
+                        </button>
+                    </div>
+
+                    {selectedProject && (
+                        <GlassCard className="project-detail-card">
+                            <div className="project-detail-toolbar">
+                                <div>
+                                    <p className="project-detail-label">선택한 프로젝트</p>
+                                    <h3>{selectedProject.title}</h3>
+                                </div>
+
+                                <div className="project-links">
+                                    <a href={selectedProject.link} className="btn btn-secondary btn-sm" target="_blank" rel="noopener noreferrer">
+                                        <ExternalLink size={16} />
+                                        GitHub
+                                    </a>
+                                    {selectedProject.projectPage && (
+                                        <a
+                                            href={selectedProject.projectPage}
+                                            className="btn btn-outline btn-sm"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            <FolderOpen size={16} />
+                                            프로젝트 페이지
+                                        </a>
+                                    )}
+                                    <button type="button" className="btn btn-outline btn-sm" onClick={() => setSelectedProject(null)}>
+                                        <X size={16} />
+                                        닫기
+                                    </button>
+                                </div>
+                            </div>
+
+                            <p className="project-detail-description">{selectedProject.description}</p>
+
+                            {selectedProject.highlights && (
+                                <ul className="project-highlights">
+                                    {selectedProject.highlights.map((highlight, idx) => (
+                                        <li key={idx}>{highlight}</li>
+                                    ))}
+                                </ul>
+                            )}
+
+                            <div className="project-tags">
+                                {selectedProject.tags.map((tag) => (
+                                    <span key={tag} className="project-tag">
+                                        {tag}
+                                    </span>
+                                ))}
+                            </div>
+                        </GlassCard>
+                    )}
                 </div>
             </div>
         </section>

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -51,7 +51,7 @@ export const skills = [
 export const projects = [
     {
         title: '같이먹자 (Eat_Together)',
-        status: '프로젝트 완료',
+        status: '완료',
         description:
             '1인 가구의 배달비 부담 문제를 해결하는 지역 기반 공동 주문 플랫폼입니다. 유저 관리 시스템과 Prometheus/Grafana 기반의 모니터링 시스템 구축을 담당했습니다. 대규모 트래픽 상황에서 발생하는 DB 커넥션 풀 고갈 문제를 Redis 캐싱 도입을 통해 해결하여 에러율을 31%에서 0%로 개선한 경험이 있습니다.',
         tags: ['Spring Boot', 'Java', 'Redis', 'Kafka', 'MySQL', 'Docker', 'Prometheus', 'Grafana', 'ELK Stack'],
@@ -68,7 +68,7 @@ export const projects = [
     },
     {
         title: 'LostArkSearch',
-        status: '프로젝트 진행 중',
+        status: '진행중',
         description:
             '로스트아크 관련 정보를 빠르게 탐색할 수 있도록 구성한 검색 프로젝트입니다. 원하는 정보를 직관적으로 찾을 수 있는 흐름에 집중하며, 검색 중심 UI와 데이터 표시 구조를 직접 구현했습니다.',
         tags: ['React', 'Vite', 'JavaScript', 'CSS'],
@@ -83,7 +83,7 @@ export const projects = [
     },
     {
         title: 'HotDealAPI - 실시간 핫딜 이벤트 시스템',
-        status: '프로젝트 완료',
+        status: '완료',
         description:
             '실시간 핫딜 이벤트 관리 및 주문 처리를 위한 백엔드 시스템입니다. 도메인 주도 설계(DDD)를 기반으로 하여 복잡한 비즈니스 로직을 명확하게 분리하였고, Redisson 분산 락을 활용하여 동시성 상황에서도 정확한 재고 관리를 구현했습니다. 또한 WebSocket을 이용해 실시간 알림 기능을 제공하며, Saga 패턴으로 도메인 간 데이터 일관성을 보장했습니다.',
         tags: ['Java 17', 'Spring Boot', 'Spring Data JPA', 'Redis', 'MySQL', 'Redisson', 'WebSocket', 'JWT', 'Docker'],
@@ -100,7 +100,7 @@ export const projects = [
     },
     {
         title: 'paw-go',
-        status: '프로젝트 진행 중',
+        status: '진행중',
         description:
             '반려동물 서비스를 위한 협업 프로젝트입니다. 팀 단위로 기능을 분담해 서비스를 함께 개발하고 있으며, 실제 운영을 고려한 구조 설계와 협업 흐름에 맞춘 개발 경험을 쌓고 있습니다.',
         tags: ['TypeScript', 'React', 'NestJS', '협업 프로젝트'],


### PR DESCRIPTION
## Summary
- 프로젝트 목록을 완료 우선 정렬의 가로 슬라이더로 재구성하고 카드 클릭 시 상세 패널과 툴바가 열리도록 개선했습니다.
- 좌우 이동 버튼과 마우스 드래그 스크롤을 추가해 프로젝트가 늘어나도 자연스럽게 탐색할 수 있게 했습니다.
- 프로젝트 상태 텍스트를 완료, 진행중으로 정리하고 진행중 배지를 주황색으로 구분했습니다.

## Test
- pnpm build